### PR TITLE
The MWSAuthToken is used to make requests on behalf of other amazon users

### DIFF
--- a/src/AmazonCore.php
+++ b/src/AmazonCore.php
@@ -430,6 +430,10 @@ abstract class AmazonCore
                 $this->urlbase = $AMAZON_SERVICE_URL;
             }
 
+            if (array_key_exists('authToken', $store[$s]) && !empty($store[$s]['authToken'])) {
+                $this->options['MWSAuthToken'] = $store[$s]['authToken'];
+            }
+
         } else {
             throw new \Exception("Store $s does not exist!");
             $this->log("Store $s does not exist!", 'Warning');

--- a/src/config/amazon-mws.php
+++ b/src/config/amazon-mws.php
@@ -7,6 +7,7 @@ return [
 			'marketplaceId' => '',
 			'keyId' => '',
 			'secretKey' => '',
+            'authToken' => '',
 			'amazonServiceUrl' => 'https://mws-eu.amazonservices.com/',
 		]
 	],


### PR DESCRIPTION
The MWSAuthToken is used to make requests on behalf of other amazon users, useful for developers working on  amazon mws apps.