### PR TITLE
Fix ineffective muteLog config setting

### DIFF
--- a/src/AmazonCore.php
+++ b/src/AmazonCore.php
@@ -371,7 +371,7 @@ abstract class AmazonCore
 
     // *
     //  * Set the config file.
-    //  * 
+    //  *
     //  * This method can be used to change the config file after the object has
     //  * been initiated. The file will not be set if it cannot be found or read.
     //  * This is useful for testing, in cases where you want to use a different file.
@@ -476,6 +476,9 @@ abstract class AmazonCore
             $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 
             $muteLog = Config::get('amazon-mws.muteLog');
+            if (isset($muteLog) && $muteLog == true) {
+                return;
+            }
 
             switch ($level) {
                 case('Info'):
@@ -493,11 +496,8 @@ abstract class AmazonCore
                 default:
                     $loglevel = 'info';
             }
-            call_user_func(array('Log', $loglevel), $msg);
 
-            if (isset($muteLog) && $muteLog == true) {
-                return;
-            }
+            call_user_func(array('Log', $loglevel), $msg);
 
             if (isset($userName) && $userName != '') {
                 $name = $userName;


### PR DESCRIPTION
The check of the muteLog config value was after the actual log method invocation, making the config value useless. Moved the muteLog config check above the logging call so that log messages are actually muted if $muteLog is true.