### PR TITLE
Added throttleCount tracking to AmazonCore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.5.9",
         "ext-curl": "*",
-        "illuminate/support": "5.*"
+        "illuminate/support": "6.*"
     },
     "require-dev": {
         "phpunit/phpunit": "5.*"

--- a/src/AmazonCore.php
+++ b/src/AmazonCore.php
@@ -104,6 +104,7 @@ abstract class AmazonCore
     protected $throttleSafe;
     protected $throttleGroup;
     protected $throttleStop = false;
+    protected $throttleCount = 0;
     protected $storeName;
     protected $options;
     protected $config;
@@ -615,6 +616,7 @@ abstract class AmazonCore
     protected function sendRequest($url, $param)
     {
         $this->log("Making request to Amazon: " . $this->options['Action']);
+        $this->throttleCount = 0;
         $response = $this->fetchURL($url, $param);
 
         if (!isset($response['code'])) {
@@ -622,6 +624,7 @@ abstract class AmazonCore
             return null;
         }
         while ($response['code'] == '503' && $this->throttleStop == false) {
+            ++$this->throttleCount;
             $this->sleep();
             $response = $this->fetchURL($url, $param);
         }
@@ -669,6 +672,16 @@ abstract class AmazonCore
         } else {
             return false;
         }
+    }
+
+    /**
+     * Gives the number of times the last call to sendRequest was throttled
+     * @return int
+     * @see sendRequest
+     */
+    public function getThrottleCountForLastRequest()
+    {
+        return $this->throttleCount;
     }
 
     /**


### PR DESCRIPTION
I really appreciate the good work you've done on this project. One thing that was important to my usage was the need to track stats on how frequently requests are being throttled.  I added a simple counter that resets each time the sendRequest method is called, and a getter method to retrieve that information.